### PR TITLE
docker: disable schedule and pin/automerge digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
     "assignees": ["slimsag"]
   },
   "docker": {
-    "schedule": null,
+    "schedule": [],
     "pinDigests": true,
     "digest": {
       "automerge": true


### PR DESCRIPTION
https://sourcegraph.slack.com/archives/C07KZF47K/p1552949151257600

~~The JSONSchema is telling me that `null` isn't a valid value to pass to `"schedule"`, I'll see if this is possible~~ Fixed in https://github.com/sourcegraph/renovate-config/pull/3/commits/d85f6fa232dd5fdb521df92410f7128d36b8c8d7