### PR TITLE
Auto merge golang.org dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,7 +54,7 @@
       "assignees": ["chrismwendt"]
     },
     {
-      "packagePatterns": ["^golang.org/"],
+      "packagePatterns": ["^golang.org/x/"],
       "masterIssueApproval": false,
       "assignees": [],
       "automerge": true


### PR DESCRIPTION
Goal:
- Always auto merge changes from golang.org (assuming CI passes)
- Use masterIssueApproval for Go deps (except for golang.org changes, which can be automerged).

See https://github.com/sourcegraph/sourcegraph/pull/3671#issuecomment-487725032

Helps https://github.com/sourcegraph/sourcegraph/issues/1290