### PR TITLE
Fix reviewers and assignees for Go dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,8 +24,8 @@
       "languages": ["golang"],
       "packagePatterns": [".*"],
       "groupName": "godeps",
-      "reviewers": ["team:core-services"],
-      "assignees": ["team:core-services"]
+      "reviewers": ["team:sourcegraph/core-services"],
+      "assignees": ["team:sourcegraph/core-services"]
     },
     {
       "packagePatterns": ["^@sourcegraph/"],


### PR DESCRIPTION
This PR didn't get anyone assigned: https://github.com/sourcegraph/sourcegraph/pull/5447

I am guessing that we need to use the full slug for the team.