### PR TITLE
Enable masterIssueApproval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   },
   "prBodyColumns": ["Package", "Type", "Update", "New value", "References", "Sourcegraph"],
   "masterIssue": true,
+  "masterIssueApproval": true,
   "updateNotScheduled": true,
   "prCreation": "immediate",
   "prHourlyLimit": 10,


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/1290

Renovate PRs are not getting merged in a timely manner and keeping them open clutters our PR list. There are currently [37 open renovate PRs](https://github.com/sourcegraph/sourcegraph/pulls/app%2Frenovate), the oldest of which is from May 1.

Enabling masterIssueApproval will prevent PRs from getting created until a developer is actually ready to upgrade a dependency, at which point they can go to the [master issue](https://github.com/sourcegraph/sourcegraph/issues/2422) to trigger a PR to be created.