### PR TITLE
Configure reviewers for npm dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,12 +19,12 @@
   "prConcurrentLimit": 50,
   "rangeStrategy": "bump",
   "postUpdateOptions": ["yarnDedupeFewer"],
-  "assignees": ["felixfbecker"],
   "docker": {
     "assignees": [],
     "pinDigests": true
   },
   "npm": {
+    "reviewers": ["team:web"],
     "labels": ["npm"]
   },
   "packageRules": [
@@ -32,8 +32,7 @@
       "languages": ["golang"],
       "packagePatterns": [".*"],
       "groupName": "godeps",
-      "reviewers": ["team:sourcegraph/core-services"],
-      "assignees": ["team:sourcegraph/core-services"],
+      "reviewers": ["team:core-services"],
       "labels": ["go"]
     },
     {
@@ -45,21 +44,18 @@
       "packageNames": ["sourcegraph"],
       "rangeStrategy": "bump",
       "schedule": [],
+      "reviewers": [],
       "automerge": true
     },
     {
       "packagePatterns": ["^@types/"],
       "rangeStrategy": "pin",
-      "assignees": [],
+      "reviewers": [],
       "automerge": true
     },
     {
-      "packageNames": ["@sourcegraph/codeintellify"],
-      "assignees": ["felixfbecker"]
-    },
-    {
       "packageNames": ["@sourcegraph/basic-code-intel"],
-      "assignees": ["chrismwendt"]
+      "reviewers": ["team:code-intel"]
     },
     {
       "packagePatterns": ["prettier"],
@@ -68,6 +64,7 @@
     {
       "packagePatterns": ["prettier", "lint", "^@sourcegraph/tsconfig$"],
       "depTypeList": ["devDependencies"],
+      "reviewers": [],
       "automerge": true
     },
     {


### PR DESCRIPTION
This is the correct syntax according to https://github.com/renovatebot/renovate/issues/1908#issuecomment-537083886

Also:
- Removed `assignees` as `reviewers` should be enough and `assignees` doesn't support teams
- Removed reviewers for automerged dependencies