### PR TITLE
Add Code Insights team as visx library reviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,10 @@
       "reviewers": ["team:code-intel"]
     },
     {
+      "packageNames": ["^@visx/"],
+      "reviewers": ["team:code-insights"]
+    },
+    {
       "packagePatterns": ["prettier"],
       "groupName": "prettier"
     },


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21525

This PR adds @sourcegraph/code-insights as a reviewers of `@visx/` chart library packages.