### PR TITLE
add test plan exceptions for all renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
   "prBodyDefinitions": {
     "Sourcegraph": "[![code search for \"{{{depName}}}\"](https://sourcegraph.com/search/badge?q=repo:%5Egithub%5C.com/{{{encodeURIComponent repository}}}%24+case:yes+-file:package%28-lock%29%3F%5C.json%7Cyarn%5C.lock+{{{encodeURIComponent depName}}}&label=matches)](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/{{{encodeURIComponent repository}}}%24+case:yes+-file:package%28-lock%29%3F%5C.json%7Cyarn%5C.lock+{{{encodeURIComponent depName}}})"
   },
+  "prBodyNotes": [
+    "Test plan: CI should pass with updated dependencies. No review required: this is an automated dependency update PR."
+  ],
   "engines": {
     "node": {
       "rangeStrategy": "widen"


### PR DESCRIPTION
Allows Renovate PRs using this config to not trip `pr-auditor` checks

https://docs.sourcegraph.com/dev/background-information/testing_principles#exceptions